### PR TITLE
文字コード設定をシンプル化

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -61,13 +61,6 @@ define('OBJECT_IMPORT_IGNORE_NULL', 1);
 /** アプリケーションオブジェクトインポートオプション: NULLプロパティ→空文字列変換 */
 define('OBJECT_IMPORT_CONVERT_NULL', 2);
 
-
-// {{{  mbstring enabled check
-function mb_enabled()
-{
-    return (extension_loaded('mbstring')) ? true : false;
-}
-
 // {{{ I18N shortcut
 /**
  *  メッセージカタログからロケールに適合するメッセージを取得します。

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -96,11 +96,13 @@ class Ethna_Controller
     protected $filter = array(
     );
 
-    /** @protected    string      使用ロケール設定 */
+    /**
+     * @protected    string ロケール名(e.x ja_JP, en_US 等),
+     *                  (ロケール名は ll_cc の形式。ll = 言語コード cc = 国コード)
+     */
     protected $locale;
 
-    /** @protected    string      クライアント側エンコーディング */
-    /**                     ブラウザからのエンコーディングを指す  */
+    /** @protected    string 内部エンコーディング */
     protected $client_encoding;
 
     /** FIXME: UnitTestCase から動的に変更されるため、public */
@@ -213,11 +215,8 @@ class Ethna_Controller
         $this->forward = $this->forward + $this->forward_default;
 
         // 初期設定
-        // フレームワークとしての内部エンコーディングはクライアント
-        // エンコーディング（=ブラウザからのエンコーディング)
-        //
-        // @see Ethna_Controller#_getDefaultLanguage
-        list($this->locale, $this->client_encoding) = $this->_getDefaultLanguage();
+        $this->locale = 'ja_JP';
+        $this->client_encoding =  'UTF-8';
 
         mb_internal_encoding($this->client_encoding);
         mb_regex_encoding($this->client_encoding);
@@ -919,7 +918,15 @@ class Ethna_Controller
         $session->restore();
 
         // 言語切り替えフックを呼ぶ
-        $this->_setLanguage($this->locale, $this->client_encoding, $this->client_encoding);
+        /**
+         *  @param  string  $locale             ロケール名(ja_JP, en_US等)
+         *                                      (ll_cc の形式。ll = 言語コード cc = 国コード)
+         */
+        //   $this->locale, $this->client_encoding を書き換えた場合は
+        //   必ず Ethna_I18N クラスの setLanguageメソッドも呼ぶこと!
+        //   さもないとカタログその他が再ロードされない！
+        $i18n = $this->getI18N();
+        $i18n->setLanguage($this->locale, $this->client_encoding, $this->client_encoding);
 
         // アクションフォーム初期化
         // フォーム定義、フォーム値設定
@@ -1596,52 +1603,6 @@ class Ethna_Controller
      */
     protected function _setDefaultTemplateEngine($renderer)
     {
-    }
-
-    /**
-     *  使用言語、ロケールを設定する
-     *  条件によって使用言語、ロケールを切り替えたい場合は、
-     *  このメソッドをオーバーライドする。
-     *
-     *  @access protected
-     *  @param  string  $locale             ロケール名(ja_JP, en_US等)
-     *                                      (ll_cc の形式。ll = 言語コード cc = 国コード)
-     *  @param  string  $system_encoding    システムエンコーディング名
-     *  @param  string  $client_encoding    クライアントエンコーディング(テンプレートのエンコーディングと考えれば良い)
-     *  @see    http://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html
-     *  @see    Ethna_Controller#_getDefaultLanguage
-     */
-    protected function _setLanguage($locale, $system_encoding = null, $client_encoding = null)
-    {
-        $this->locale = $locale;
-        $this->client_encoding = $client_encoding;
-
-        //   $this->locale, $this->client_encoding を書き換えた場合は
-        //   必ず Ethna_I18N クラスの setLanguageメソッドも呼ぶこと!
-        //   さもないとカタログその他が再ロードされない！
-        $i18n = $this->getI18N();
-        $i18n->setLanguage($locale, $system_encoding, $client_encoding);
-    }
-
-    /**
-     *  デフォルト状態での使用言語を取得する
-     *  外部に出力されるEthnaのエラーメッセージ等のエンコーディングを
-     *  切り替えたい場合は、このメソッドをオーバーライドする。
-     *
-     *  @access protected
-     *  @return array   ロケール名(e.x ja_JP, en_US 等),
-     *                  システムエンコーディング名,
-     *                  クライアントエンコーディング名
-     *                  (= テンプレートのエンコーディングと考えてよい) の配列
-     *                  (ロケール名は ll_cc の形式。ll = 言語コード cc = 国コード)
-     *
-     *  WARNING!! : クライアントエンコーディング名が、フレームワークの内部エンコーデ
-     *              ィングとして設定されます。つまり、クライアントエンコーディングで
-     *              ブラウザからの入力は入ってくるものと想定しています！
-     */
-    protected function _getDefaultLanguage()
-    {
-        return array('ja_JP', 'UTF-8');
     }
 
     /**

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -716,14 +716,13 @@ class Ethna_Controller
      *
      *  @access public
      *  @return array   ロケール名(e.x ja_JP, en_US 等),
-     *                  システムエンコーディング名,
      *                  クライアントエンコーディング名 の配列
      *                  (ロケール名は、ll_cc の形式。ll = 言語コード cc = 国コード)
      *  @see http://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html
      */
     public function getLanguage()
     {
-        return array($this->locale, $this->client_encoding, $this->client_encoding);
+        return array($this->locale, $this->client_encoding);
     }
 
     /**

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -221,10 +221,10 @@ class Ethna_Controller
         //
         // @see Ethna_Controller#_getDefaultLanguage
         list($this->locale, $this->system_encoding, $this->client_encoding) = $this->_getDefaultLanguage();
-        if (mb_enabled()) {
-            mb_internal_encoding($this->client_encoding);
-            mb_regex_encoding($this->client_encoding);
-        }
+
+        mb_internal_encoding($this->client_encoding);
+        mb_regex_encoding($this->client_encoding);
+
         $this->config = $this->getConfig();
         $this->dsn = $this->_prepareDSN();
         $this->url = $this->config->get('url');

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -99,9 +99,6 @@ class Ethna_Controller
     /** @protected    string      使用ロケール設定 */
     protected $locale;
 
-    /** @protected    string      システム側エンコーディング */
-    protected $system_encoding;
-
     /** @protected    string      クライアント側エンコーディング */
     /**                     ブラウザからのエンコーディングを指す  */
     protected $client_encoding;
@@ -220,7 +217,7 @@ class Ethna_Controller
         // エンコーディング（=ブラウザからのエンコーディング)
         //
         // @see Ethna_Controller#_getDefaultLanguage
-        list($this->locale, $this->system_encoding, $this->client_encoding) = $this->_getDefaultLanguage();
+        list($this->locale, $this->client_encoding) = $this->_getDefaultLanguage();
 
         mb_internal_encoding($this->client_encoding);
         mb_regex_encoding($this->client_encoding);
@@ -727,7 +724,7 @@ class Ethna_Controller
      */
     public function getLanguage()
     {
-        return array($this->locale, $this->system_encoding, $this->client_encoding);
+        return array($this->locale, $this->client_encoding, $this->client_encoding);
     }
 
     /**
@@ -753,7 +750,7 @@ class Ethna_Controller
     {
         $this->locale = $locale;
         $i18n = $this->getI18N();
-        $i18n->setLanguage($this->locale, $this->system_encoding, $this->client_encoding);
+        $i18n->setLanguage($this->locale, $this->client_encoding, $this->client_encoding);
     }
 
     /**
@@ -777,7 +774,7 @@ class Ethna_Controller
     {
         $this->client_encoding = $client_encoding;
         $i18n = $this->getI18N();
-        $i18n->setLanguage($this->locale, $this->system_encoding, $this->client_encoding);
+        $i18n->setLanguage($this->locale, $this->client_encoding, $this->client_encoding);
     }
 
     /**
@@ -922,7 +919,7 @@ class Ethna_Controller
         $session->restore();
 
         // 言語切り替えフックを呼ぶ
-        $this->_setLanguage($this->locale, $this->system_encoding, $this->client_encoding);
+        $this->_setLanguage($this->locale, $this->client_encoding, $this->client_encoding);
 
         // アクションフォーム初期化
         // フォーム定義、フォーム値設定
@@ -1617,7 +1614,6 @@ class Ethna_Controller
     protected function _setLanguage($locale, $system_encoding = null, $client_encoding = null)
     {
         $this->locale = $locale;
-        $this->system_encoding = $system_encoding;
         $this->client_encoding = $client_encoding;
 
         //   $this->locale, $this->client_encoding を書き換えた場合は
@@ -1645,7 +1641,7 @@ class Ethna_Controller
      */
     protected function _getDefaultLanguage()
     {
-        return array('ja_JP', 'UTF-8', 'UTF-8');
+        return array('ja_JP', 'UTF-8');
     }
 
     /**

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -749,7 +749,7 @@ class Ethna_Controller
     {
         $this->locale = $locale;
         $i18n = $this->getI18N();
-        $i18n->setLanguage($this->locale, $this->client_encoding, $this->client_encoding);
+        $i18n->setLanguage($this->locale, $this->client_encoding);
     }
 
     /**
@@ -773,7 +773,7 @@ class Ethna_Controller
     {
         $this->client_encoding = $client_encoding;
         $i18n = $this->getI18N();
-        $i18n->setLanguage($this->locale, $this->client_encoding, $this->client_encoding);
+        $i18n->setLanguage($this->locale, $this->client_encoding);
     }
 
     /**
@@ -918,15 +918,11 @@ class Ethna_Controller
         $session->restore();
 
         // 言語切り替えフックを呼ぶ
-        /**
-         *  @param  string  $locale             ロケール名(ja_JP, en_US等)
-         *                                      (ll_cc の形式。ll = 言語コード cc = 国コード)
-         */
         //   $this->locale, $this->client_encoding を書き換えた場合は
         //   必ず Ethna_I18N クラスの setLanguageメソッドも呼ぶこと!
         //   さもないとカタログその他が再ロードされない！
         $i18n = $this->getI18N();
-        $i18n->setLanguage($this->locale, $this->client_encoding, $this->client_encoding);
+        $i18n->setLanguage($this->locale, $this->client_encoding);
 
         // アクションフォーム初期化
         // フォーム定義、フォーム値設定

--- a/src/I18N.php
+++ b/src/I18N.php
@@ -37,9 +37,6 @@ class Ethna_I18N
     /** @protected    string  アプリケーションID */
     protected $appid;
 
-    /** @protected    string  システム側エンコーディング */
-    protected $systemencoding;
-
     /** @protected    string  クライアント側エンコーディング */
     protected $clientencoding;
 
@@ -102,14 +99,12 @@ class Ethna_I18N
      *  @access public
      *  @param  string  $locale         ロケール名(e.x ja_JP, en_US 等)
      *                                  (ll_cc の形式。ll = 言語コード cc = 国コード)
-     *  @param  string  $systemencoding システムエンコーディング名
-     *  @param  string  $clientencoding クライアントエンコーディング名
-     *                                  (=テンプレートのエンコーディングと考えてよい)
+     *  @param  string  $clientencoding 内部エンコーディング名
      *  @see    http://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html 
      */
-    public function setLanguage($locale, $systemencoding = null, $clientencoding = null)
+    public function setLanguage($locale, $clientencoding = null)
     {
-        setlocale(LC_ALL, $locale . ($systemencoding !== null ? "." . $systemencoding : ""));
+        setlocale(LC_ALL, $locale . ($clientencoding !== null ? "." . $clientencoding : ""));
 
         if ($this->use_gettext) {
             bind_textdomain_codeset($locale, $clientencoding);
@@ -118,7 +113,6 @@ class Ethna_I18N
         }
 
         $this->locale = $locale;
-        $this->systemencoding = $systemencoding;
         $this->clientencoding = $clientencoding;
 
         //  強制的にメッセージカタログ再生成

--- a/src/I18N.php
+++ b/src/I18N.php
@@ -201,7 +201,7 @@ class Ethna_I18N
         //    このメソッドを呼び出すと、ロケール名が空になる
         //    その場合は Ethna_Controller の設定を補う
         if (empty($this->locale)) {
-            list($this->locale, $sys_enc, $cli_enc) = $this->ctl->getLanguage();
+            list($this->locale, $cli_enc) = $this->ctl->getLanguage();
         }
 
         //    ロケールディレクトリが存在しない場合は、E_NOTICEを出し、

--- a/src/Plugin/Validator/Max.php
+++ b/src/Plugin/Validator/Max.php
@@ -101,7 +101,7 @@ class Ethna_Plugin_Validator_Max extends Ethna_Plugin_Validator
                 $plugin = $this->backend->getPlugin();
 
                 //  select Plugin.
-                if (mb_enabled() && strcasecmp('UTF-8', $client_enc) == 0) {
+                if (strcasecmp('UTF-8', $client_enc) == 0) {
                     $plugin_name = 'Mbstrmax';
                     $params['mbstrmax'] = $params['max'];
                 } elseif (strcasecmp('EUC-JP', $client_enc == 0)

--- a/src/Plugin/Validator/Min.php
+++ b/src/Plugin/Validator/Min.php
@@ -101,7 +101,7 @@ class Ethna_Plugin_Validator_Min extends Ethna_Plugin_Validator
                 $plugin = $this->backend->getPlugin();
 
                 //  select Plugin.
-                if (mb_enabled() && strcasecmp('UTF-8', $client_enc) == 0) {
+                if (strcasecmp('UTF-8', $client_enc) == 0) {
                     $plugin_name = 'Mbstrmin';
                     $params['mbstrmin'] = $params['min'];
                 } elseif (strcasecmp('EUC-JP', $client_enc == 0)

--- a/src/Plugin/Validator/Strmaxcompat.php
+++ b/src/Plugin/Validator/Strmaxcompat.php
@@ -48,9 +48,8 @@ class Ethna_Plugin_Validator_Strmaxcompat extends Ethna_Plugin_Validator
 
         $ctl = $this->backend->getController();
         $client_enc = $ctl->getClientEncoding();
-        if (mb_enabled()
-        && (strcasecmp('EUC-JP', $client_enc) != 0
-         && strcasecmp('eucJP-win', $client_enc) != 0)) {
+        if (strcasecmp('EUC-JP', $client_enc) != 0
+         && strcasecmp('eucJP-win', $client_enc) != 0) {
             $var = mb_convert_encoding($var, 'EUC-JP', $client_enc);
         }
 

--- a/src/Plugin/Validator/Strmincompat.php
+++ b/src/Plugin/Validator/Strmincompat.php
@@ -47,9 +47,8 @@ class Ethna_Plugin_Validator_Strmincompat extends Ethna_Plugin_Validator
 
         $ctl = $this->backend->getController();
         $client_enc = $ctl->getClientEncoding();
-        if (mb_enabled()
-        && (strcasecmp('EUC-JP', $client_enc) != 0
-         && strcasecmp('eucJP-win', $client_enc) != 0)) {
+        if (strcasecmp('EUC-JP', $client_enc) != 0
+         && strcasecmp('eucJP-win', $client_enc) != 0) {
             $var = mb_convert_encoding($var, 'EUC-JP', $client_enc);
         }
 

--- a/src/View/Json.php
+++ b/src/View/Json.php
@@ -35,7 +35,7 @@ class Ethna_View_Json extends Ethna_ViewClass
     public function preforward($encode_param = array(), $header = false)
     {
         $client_enc = $this->ctl->getClientEncoding();
-        if (mb_enabled() && strcasecmp('UTF-8', $client_enc) != 0) {
+        if (strcasecmp('UTF-8', $client_enc) != 0) {
             mb_convert_variables('UTF-8', $client_enc, $encode_param);
         }
         $encoded_param = json_encode($encode_param);


### PR DESCRIPTION
- mb_enabledを廃止。(mbstringモジュールが入ってるのを必須要件とする)
- system_encoding変数が全く使われていないので廃止
- 内部仕様をリファクタリング
