### PR TITLE
クロスサイトリクエストフォージェリの対策コード部分の修正

### DIFF
--- a/src/Plugin/Cachemanager.php
+++ b/src/Plugin/Cachemanager.php
@@ -32,17 +32,25 @@ class Ethna_Plugin_Cachemanager
     /** @protected    object  Ethna_Config        設定オブジェクト    */
     protected $config;
 
+    /** @protected    string  プラグインの種別(Cachemanager) */
+    protected $type;
+
+    /** @protected    string  プラグインの名前(Memcache) */
+    protected $name;
+
 
     /**
      *  コンストラクタ
      *
      *  @access public
      */
-    public function __construct($controller)
+    public function __construct($controller, $type = null, $name = null)
     {
         $this->controller = $controller;
         $this->backend = $this->controller->getBackend();
         $this->config = $this->controller->getConfig();
+        $this->type = $type;
+        $this->name = $name;
 
 	// load config
 	$this->_loadConfig();

--- a/src/Plugin/Cachemanager/Memcache.php
+++ b/src/Plugin/Cachemanager/Memcache.php
@@ -47,9 +47,9 @@ class Ethna_Plugin_Cachemanager_Memcache extends Ethna_Plugin_Cachemanager
      *
      *  @access public
      */
-    public function __construct($controller)
+    public function __construct($controller, $type, $name)
     {
-        parent::__construct($controller);
+        parent::__construct($controller, $type, $name);
         $this->memcache_pool = array();
     }
 

--- a/src/Plugin/Smarty/function.csrfid.php
+++ b/src/Plugin/Smarty/function.csrfid.php
@@ -16,14 +16,14 @@
 function smarty_function_csrfid($params, &$smarty)
 {
     $c = Ethna_Controller::getInstance();
-    $name = $c->config->get('csrf');
+    $name = $c->getConfig()->get('csrf');
     if (is_null($name)) {
         $name = 'Session';
     }
     $plugin = $c->getPlugin();
     $csrf = $plugin->getPlugin('Csrf', $name);
     $csrfid = $csrf->get();
-    $token_name = $csrf->getName();
+    $token_name = $csrf->getTokenName();
     if (isset($params['type']) && $params['type'] == 'get') {
         return sprintf("%s=%s", $token_name, $csrfid);
     } else {

--- a/src/Util.php
+++ b/src/Util.php
@@ -103,7 +103,7 @@ class Ethna_Util
     public static function isCsrfSafe()
     {
         $c = Ethna_Controller::getInstance();
-        $name = $c->config->get('csrf');
+        $name = $c->getConfig()->get('csrf');
 
         if (is_null($name)) {
             $name = 'Session';
@@ -125,7 +125,7 @@ class Ethna_Util
     public static function setCsrfID()
     {
         $c = Ethna_Controller::getInstance();
-        $name = $c->config->get('csrf');
+        $name = $c->getConfig()->get('csrf');
         
         if (is_null($name)) {
             $name = 'Session';


### PR DESCRIPTION
Ethnaのクロスサイトリクエストフォージェリの対策コード(Ethna_Util::setCsrfID())を使用しようとすると "Cannot access protected property Eventgrid_Controller::$config" というエラーが、またテンプレートに {csrfid} を追加すると "Call to undefined method Ethna_Plugin_Csrf_Session::getName()" というエラーが発生したので、それに対応する修正を追加しました。
