### PR TITLE
Csrf対策コードを使おうとするとPHPエラーが発生する現象の修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # 変更点一覧
 
 ## 2.19での変更点
+* [core] mbstringモジュールを必須要件としました。
+* [core] system_encoding変数は使われていなかったので廃止しました。
+* [core] その他、language/encodingまわりの無駄なメソッドを削除しました。
 * [mail] (B.C.) MailSenderがcharset=utf8でメール送信するようになりました。内部エンコーディングがUTF-8になっているのを前提としています。
 
 ## 2.18での変更点

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,7 +10,7 @@
  */
 
 /** バージョン定義 */
-define('ETHNA_VERSION', '2.15.0');
+define('ETHNA_VERSION', '2.19.0');
 
 //  PHP 5.1.0 以降向けの変更
 //  date.timezone が設定されていないと

--- a/src/Plugin/Smarty/function.csrfid.php
+++ b/src/Plugin/Smarty/function.csrfid.php
@@ -16,14 +16,14 @@
 function smarty_function_csrfid($params, &$smarty)
 {
     $c = Ethna_Controller::getInstance();
-    $name = $c->config->get('csrf');
+    $name = $c->getConfig()->get('csrf');
     if (is_null($name)) {
         $name = 'Session';
     }
     $plugin = $c->getPlugin();
     $csrf = $plugin->getPlugin('Csrf', $name);
     $csrfid = $csrf->get();
-    $token_name = $csrf->getName();
+    $token_name = $csrf->getTokenName();
     if (isset($params['type']) && $params['type'] == 'get') {
         return sprintf("%s=%s", $token_name, $csrfid);
     } else {

--- a/src/Util.php
+++ b/src/Util.php
@@ -103,7 +103,7 @@ class Ethna_Util
     public static function isCsrfSafe()
     {
         $c = Ethna_Controller::getInstance();
-        $name = $c->config->get('csrf');
+        $name = $c->getConfig()->get('csrf');
 
         if (is_null($name)) {
             $name = 'Session';
@@ -125,7 +125,7 @@ class Ethna_Util
     public static function setCsrfID()
     {
         $c = Ethna_Controller::getInstance();
-        $name = $c->config->get('csrf');
+        $name = $c->getConfig()->get('csrf');
         
         if (is_null($name)) {
             $name = 'Session';


### PR DESCRIPTION
EthnamのCSRF対策コードを使用すると
Cannot access protected property Eventgrid_Controller::$config
Call to undefined method Ethna_Plugin_Csrf_Session::getName()
が発生する現象の修正
