### PR TITLE
CacheManagerのMemcache使用時、設定ファイルのPlugin記述を読み込まない現象の修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # 変更点一覧
 
 ## 2.19での変更点
+* [core] mbstringモジュールを必須要件としました。
+* [core] system_encoding変数は使われていなかったので廃止しました。
+* [core] その他、language/encodingまわりの無駄なメソッドを削除しました。
 * [mail] (B.C.) MailSenderがcharset=utf8でメール送信するようになりました。内部エンコーディングがUTF-8になっているのを前提としています。
 
 ## 2.18での変更点

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,7 +10,7 @@
  */
 
 /** バージョン定義 */
-define('ETHNA_VERSION', '2.15.0');
+define('ETHNA_VERSION', '2.19.0');
 
 //  PHP 5.1.0 以降向けの変更
 //  date.timezone が設定されていないと

--- a/skel/etc.config.php
+++ b/skel/etc.config.php
@@ -95,8 +95,8 @@ $config['plugin'] = array(
 
     // memcache
     // sample-1: single (or default) memcache
-    'cachemanager' => array(
-        //'memcache' => array(
+    'Cachemanager' => array(
+        //'Memcache' => array(
         //     'host' => 'localhost',
         //     'port' => 11211,
         //     'use_pconnect' => false,

--- a/src/Plugin/Cachemanager.php
+++ b/src/Plugin/Cachemanager.php
@@ -32,17 +32,24 @@ class Ethna_Plugin_Cachemanager
     /** @protected    object  Ethna_Config        設定オブジェクト    */
     protected $config;
 
+    /** @protected    string  プラグインの種別(Cachemanager) */
+    protected $type;
+
+    /** @protected    string  プラグインの名前(Memcacheなど) */
+    protected $name;
 
     /**
      *  コンストラクタ
      *
      *  @access public
      */
-    public function __construct($controller)
+    public function __construct($controller, $type = null, $name = null)
     {
         $this->controller = $controller;
         $this->backend = $this->controller->getBackend();
         $this->config = $this->controller->getConfig();
+        $this->type = $type;
+        $this->name = $name;
 
 	// load config
 	$this->_loadConfig();

--- a/src/Plugin/Cachemanager/Memcache.php
+++ b/src/Plugin/Cachemanager/Memcache.php
@@ -47,9 +47,9 @@ class Ethna_Plugin_Cachemanager_Memcache extends Ethna_Plugin_Cachemanager
      *
      *  @access public
      */
-    public function __construct($controller)
+    public function __construct($controller, $type, $name)
     {
-        parent::__construct($controller);
+        parent::__construct($controller, $type, $name);
         $this->memcache_pool = array();
     }
 


### PR DESCRIPTION
CacheManagerのMemcacheを使用した時、etc/config.phpの $config['plugin'] に書いた設定を読み込まず、$config_default の値を使う点を修正しました（自分が使いたかったmemcacheプラグインのみ修正）。
他のプラグインも $type, $name をコンストラクタで渡す修正が必要かも知れません。

また、$config['plugin'] の設定は、"Cachemanager", "Memcache" のように先頭を大文字にする必要があるようなので、テンプレートのetc.config.phpの記述も直しました。
