### PR TITLE
getManagerでアプリケーションマネージャを取得する時、自動的にincludeを試みる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # 変更点一覧
 
 ## 2.19での変更点
+* [core] mbstringモジュールを必須要件としました。
+* [core] system_encoding変数は使われていなかったので廃止しました。
+* [core] その他、language/encodingまわりの無駄なメソッドを削除しました。
 * [mail] (B.C.) MailSenderがcharset=utf8でメール送信するようになりました。内部エンコーディングがUTF-8になっているのを前提としています。
 
 ## 2.18での変更点

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,7 +10,7 @@
  */
 
 /** バージョン定義 */
-define('ETHNA_VERSION', '2.15.0');
+define('ETHNA_VERSION', '2.19.0');
 
 //  PHP 5.1.0 以降向けの変更
 //  date.timezone が設定されていないと

--- a/src/ClassFactory.php
+++ b/src/ClassFactory.php
@@ -79,6 +79,10 @@ class Ethna_ClassFactory
         //  すでにincludeされていなければ、includeを試みる
         //  ここで返されるクラス名は、AppManagerの命名規約によるもの
         $class_name = $this->controller->getManagerClassName($type);
+        if (class_exists($class_name) === false
+            && $this->_include($class_name) === false) {
+            return null;  //  include 失敗。戻り値はNULL。
+        }
 
         //  PHPのクラス名は大文字小文字を区別しないので、
         //  同じクラス名と見做されるものを指定した場合には


### PR DESCRIPTION
EthnamのgetManagerでアプリケーションマネージャを取得する時、そのクラスが事前にrequireされていないとクラス生成時にエラーが発生するので、本家EthnaのgetManagerと同様にインクルードする処理を追加しました
