### PR TITLE
eliminate check_remote_addr feature. This is useless for mobile phones.

### DIFF
--- a/skel/etc.config.php
+++ b/skel/etc.config.php
@@ -57,7 +57,6 @@ $config = array(
     'session' => array(
         'handler'   => 'files',
         'path'      => 'tmp',
-        'check_remote_addr'      => true,
         //'cache_limiter' => 'private_no_expire',
         //'cache_expire'  => '180',
     ),


### PR DESCRIPTION
携帯電話はIPがころころ変わる。この機能はまったく使わないので不要。
