### PR TITLE
revive memcached plugin

### DIFF
--- a/src/Plugin/Cachemanager/Memcached.php
+++ b/src/Plugin/Cachemanager/Memcached.php
@@ -35,16 +35,15 @@ class Ethna_Plugin_Cachemanager_Memcached extends Ethna_Plugin_Cachemanager
     /**#@-*/
 
     /**
-     *  _load
+     *  constructor
      *
-     *  @access protected
      */
-    protected function _load()
+    public function __construct($controller)
     {
-        parent::_load();
+        parent::__construct($controller);
 
         if ($this->opt['use_pconnect']) {
-            $this->m = new Memcached($this->ctl->getAppId());
+            $this->m = new Memcached($controller->getAppId());
         }
         else {
             $this->m = new Memcached();


### PR DESCRIPTION
# 背景

PHP extensionには`memcache`と`memcached`の異なる２つのライブラリが存在する。

http://pecl.php.net/package/memcached
http://pecl.php.net/package/memcache

memcacheの方は長いことメンテナンスされておらず、PHP7でインストールできない。
一方memcachedの方はphpsevenブランチがありPHP7にインストールできる。

EthnamではMemcached.phpの方はv2.7から動かないまま放置されていたが、今後のことを考えるとむしろこっちが主流になる可能性がある。
