### PR TITLE
fix phpdoc

### DIFF
--- a/src/ActionError.php
+++ b/src/ActionError.php
@@ -180,7 +180,7 @@ class Ethna_ActionError
     /**
      *  アプリケーションエラーメッセージを取得する
      *
-     *  @param  array   エラーエントリ
+     *  @param  array   $error エラーエントリ
      *  @return string  エラーメッセージ
      */
     protected function getMessageByEntry(&$error)


### PR DESCRIPTION
PHPDocを以下の形式に合わせる。
@param datatype $paramname description
他のPHPDocも可能なら直したいです。
