### PR TITLE
MailSenderでヘッダがencode_MIMEによって行が分割されると正しく動作しないバグを修正

### DIFF
--- a/src/MailSender.php
+++ b/src/MailSender.php
@@ -261,7 +261,7 @@ class Ethna_MailSender
             $header[$i] = array();
             $header[$i][] = $key;
             $header[$i][] = preg_replace_callback('/([^\x00-\x7f]+)/',
-	        function($matches){ return Ethna_Util::encode_MIME($matches[1]); },
+	        function($matches){ return Ethna_Util::encode_MIME($matches[1], "\n"); },
 		$value);
         }
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -316,9 +316,10 @@ class Ethna_Util
      *
      *  @access public
      *  @param  string  $string     MIMEエンコードする文字列
+     *  @param  string  $linefeed   EOLマーカー
      *  @return エンコード済みの文字列
      */
-    public static function encode_MIME($string)
+    public static function encode_MIME($string, $linefeed = "\r\n")
     {
         $pos = 0;
         $split = 36;
@@ -327,7 +328,7 @@ class Ethna_Util
         {
             $tmp = mb_strimwidth($string, $pos, $split, "");
             $pos += mb_strlen($tmp);
-            $_string .= (($_string)? ' ' : '') . mb_encode_mimeheader($tmp, 'UTF-8');
+            $_string .= (($_string)? ' ' : '') . mb_encode_mimeheader($tmp, 'UTF-8', 'B', $linefeed);
         }
 
         return $_string;


### PR DESCRIPTION
# 現象
テンプレートのヘッダのfromにある程度以上長い文字列を入れると、
以下のようなエラーが出てメールが送信されなかった。
```
[PHP] E_WARNING: mail(): Multiple or malformed newlines found in additional_header in <略>
```

# 原因
mb_encode_mimeheader()はヘッダーのエンコード結果が74文字以上だと行が折りたたまれ、デフォルトだとCRLFで改行されるが、mailsenderは内部的にLFを改行コードとして使用しており、最後にLFをCRLFに置換するので、改行コードがCRCRLFのような正しくない状態になり、エラーが出ていた。

# 対策
mb_encode_mimeheader()のEOLマーカーとしてLFを指定するようにした。