### PR TITLE
e修飾子付きpreg_replaceをpreg_replace_callbackに変更

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -1235,7 +1235,7 @@ class Ethna_Controller
         }
         $target = $match[1];
 
-        $action_name = substr(preg_replace('/([A-Z])/e', "'_' . strtolower('\$1')", $target), 1);
+        $action_name = substr(preg_replace_callback('/([A-Z])/', function(array $matches){return '_' . strtolower($matches[1]);}, $target), 1);
 
         return $action_name;
     }
@@ -1312,7 +1312,7 @@ class Ethna_Controller
         }
         $target = $match[1];
 
-        $action_name = substr(preg_replace('/([A-Z])/e', "'_' . strtolower('\$1')", $target), 1);
+        $action_name = substr(preg_replace_callback('/([A-Z])/', function(array $matches){return '_' . strtolower($matches[1]);}, $target), 1);
 
         return $action_name;
     }

--- a/src/Plugin/Cachemanager/Localfile.php
+++ b/src/Plugin/Cachemanager/Localfile.php
@@ -267,6 +267,6 @@ class Ethna_Plugin_Cachemanager_Localfile extends Ethna_Plugin_Cachemanager
      */
     private function _escape($string)
     {
-        return preg_replace('/([^0-9A-Za-z_])/e', "sprintf('%%%02X', ord('\$1'))", $string);
+        return preg_replace_callback('/([^0-9A-Za-z_])/', function($matches){return sprintf('%%%02X', ord($matches[1]));}, $string);
     }
 }


### PR DESCRIPTION
# 背景

`preg_replace` 関数で e修飾子を使っている箇所がある
これは php5.6 で deprecated、php 7.0 で廃止されているため、このままだとphp 7.0以降でうまく動かない。

# 対処

preg_replace_callbackで書き換えた
