### PR TITLE
php7.1で発生する'Warning: A non-numeric value encountered' ワーニングの除去

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -501,8 +501,8 @@ class Ethna_Util
                         }
                         $v = preg_split('/[:\s]+/', $s);
                         if (is_array($v) && count($v) > 10) {
-                            $rx += $v[2];
-                            $tx += $v[10];
+                            $rx += intval($v[2]);
+                            $tx += intval($v[10]);
                         }
                     }
                 }


### PR DESCRIPTION
# 現象

php 7.1 で `Ethna_Util::getRandom` メソッドを呼び出すと
```
PHP 4:E_WARNING, Warning: A non-numeric value encountered in /path/to/project/vendor/ethnam/ethnam/src/Util.php on line 503
```
ワーニングが発生する

# 原因

`/proc/net/dev` から取り出した数値を明示的にintに変換していない。
文字列のまま計算をしているため、以上のようなwarningが発生している

# 対処

明示的にintに変更して計算に利用するようにした
