### PR TITLE
php7.2でのワーニング抑止

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -976,7 +976,7 @@ class Ethna_Controller
         $this->logger->log(LOG_DEBUG, 'form_action_name[%s]', $form_action_name);
 
         // フォームからの指定が無い場合はエントリポイントに指定されたデフォルト値を利用する
-        if ($form_action_name == "" && count($default_action_name) > 0) {
+        if ($form_action_name == "" && !empty($default_action_name)) {
             $tmp = is_array($default_action_name) ? $default_action_name[0] : $default_action_name;
             if ($tmp{strlen($tmp)-1} == '*') {
                 $tmp = substr($tmp, 0, -1);

--- a/src/DB.php
+++ b/src/DB.php
@@ -197,7 +197,7 @@ class Ethna_DB
             $parsed['dbsyntax'] = $str;
         }
 
-        if (!count($dsn)) {
+        if (empty($dsn)) {
             return $parsed;
         }
 

--- a/src/Plugin/Smarty/modifier.count.php
+++ b/src/Plugin/Smarty/modifier.count.php
@@ -19,5 +19,8 @@
  */
 function smarty_modifier_count($array)
 {
-    return count($array);
+    if (is_array($array)) {
+        return count($array);
+    }
+    return 0;
 }


### PR DESCRIPTION
php7.2で、Countableでない変数にcount関数を使用するとWARNINGが出ます。

変数がCountableではない可能性がある場合に、countを使わない、もしくは
事前にチェックを行うようにし、WARNINGが出ないように修正しました。