### PR TITLE
Localfile をキャッシュに使うときの初期設定がないのでエラーとなるのを修正

### DIFF
--- a/src/Plugin/Cachemanager/Localfile.php
+++ b/src/Plugin/Cachemanager/Localfile.php
@@ -22,6 +22,9 @@ class Ethna_Plugin_Cachemanager_Localfile extends Ethna_Plugin_Cachemanager
 
     /**#@-*/
 
+    /** @var    array   plugin configure */
+    protected $config_default = '';
+
     /**
      *  キャッシュに設定された値を取得する
      *

--- a/src/Plugin/Cachemanager/Localfile.php
+++ b/src/Plugin/Cachemanager/Localfile.php
@@ -23,7 +23,7 @@ class Ethna_Plugin_Cachemanager_Localfile extends Ethna_Plugin_Cachemanager
     /**#@-*/
 
     /** @var    array   plugin configure */
-    protected $config_default = '';
+    protected $config_default = array();
 
     /**
      *  キャッシュに設定された値を取得する


### PR DESCRIPTION
## 変更点

キャッシュマネージャとして Localfile を選んだ時に、標準では現状ではエラーとなる。
親クラスで `$config_default` がを読み取っているのが問題なので、空文字列を入れて対処する。
もう少し綺麗な書き方もあると思うが、使用箇所からこの対処で問題なく動作する。