### PR TITLE
テンポラリファイル削除時のエラーを抑制する

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -716,9 +716,9 @@ class Ethna_Util
                     continue;
                 } else if (strncmp($file, $prefix, strlen($prefix)) == 0) {
                     $f = $c->getDirectory('tmp') . "/" . $file;
-                    $st = stat($f);
+                    $st = @stat($f);
                     if ($st[9] + $timeout < time()) {
-                        unlink($f);
+                        @unlink($f);
                     }
                 }
             }


### PR DESCRIPTION
```
E_WARNING: unlink(...): そのようなファイルやディレクトリはありません in .../vendor/ethnam/ethnam/src/Util.php on line 721
```
や
```
 E_WARNING: stat(): stat failed for ... in .../vendor/ethnam/ethnam/src/Util.php on line 719
```
といったエラーが稀に出ることがあります。
これは`readdir()`と`stat()`、`unlink()`の間で別プロセスによってテンポラリファイルが削除されたためと考えられます。
このエラーを出ないようにするため、stat()とunlink()のエラーを抑制しました。ここはテンポラリファイルの削除処理で特に重要でなく、失敗しても次の処理で消えるはずなので特に握りつぶす事による害は少ないと思われます。