### PR TITLE
getOneの返り値がnullになる場合があることをphpdocに追記

### DIFF
--- a/src/DB/ADOdb.php
+++ b/src/DB/ADOdb.php
@@ -234,9 +234,9 @@ class Ethna_DB_ADOdb extends Ethna_DB
      *  結果レコードセットのうち第１行第１列目の値を返す
      *
      *  @access public
-     *  @param  string  $query  SQL
-     *  @param  mixed   $inputarr  プレースホルダ(スカラまたは配列)
-     *  @return string  $value
+     *  @param  string       $query     SQL
+     *  @param  mixed        $inputarr  プレースホルダ(スカラまたは配列)
+     *  @return string|null  $value     (結果レコードセットが0件ならnull)
      */
     public function getOne($query, $inputarr = false)
     {


### PR DESCRIPTION
取得レコードが0件の場合にgetOneがnullを返してくることが分かったので、
その旨をphpdocに追記しました。

### Refs

[ethna - ADOdb.php - getOne](https://github.com/ethna/ethna-db/blob/3ee1512f73da70d17e9f5808a99eecbd35e6e4aa/class/Ethna/DB/ADOdb.php#L229-L242)
[ADOdb - adodb.inc.php - GetOne](https://github.com/ADOdb/ADOdb/blob/f4c781acd7ab8f3de5419ae7460498d5793a776a/adodb.inc.php#L1736-L1763)